### PR TITLE
Made subscribing buffered (like with posting events), other fixes,

### DIFF
--- a/banji.go
+++ b/banji.go
@@ -67,8 +67,8 @@ func (e *EventEmbed) Canceled() bool {
 }
 
 func (e *EventEmbed) mark() {
-	e.postmark = time.Now()
 	e.id = uuid.New()
+	e.postmark = time.Now()
 	e.canceled.Store(false)
 }
 
@@ -87,6 +87,6 @@ func (r *ReceiverEmbed) Postmark() time.Time {
 }
 
 func (r *ReceiverEmbed) mark() {
-	r.postmark = time.Now()
 	r.id = uuid.New()
+	r.postmark = time.Now()
 }

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/AndrewChon/gsync"
 	"github.com/AndrewChon/pqueue"
-
 	"github.com/google/uuid"
 )
 
@@ -40,36 +39,44 @@ type Bus[EM Emittable, SU Subscriber[EM]] struct {
 
 	bufferQueue  PriorityQueue[uint8, EM]
 	workingQueue PriorityQueue[uint8, EM]
-	subscribers  gsync.Map[string, []SU]
 
-	bufferQueueCond   *sync.Cond
-	bufferQueueLocked bool
+	wp *workerPool
 
-	demuxSema chan struct{}
+	subscribeQueue   *pqueue.CircularBuffer[SU]
+	unsubscribeQueue *pqueue.CircularBuffer[SU]
+	subscribers      gsync.Map[string, []SU]
+
+	bufferQueueMu      sync.Mutex
+	subscribeQueueMu   sync.Mutex
+	unsubscribeQueueMu sync.Mutex
 }
 
 func NewBus[EM Emittable, SU Subscriber[EM]](opts ...Option) *Bus[EM, SU] {
 	options := NewOptions(opts...)
 	b := &Bus[EM, SU]{
-		options:         options,
-		bufferQueue:     pqueue.NewBinary[uint8, EM](),
-		workingQueue:    pqueue.NewBinary[uint8, EM](),
-		bufferQueueCond: sync.NewCond(&sync.Mutex{}),
-		demuxSema:       make(chan struct{}, options.Demuxers),
+		options:          options,
+		bufferQueue:      pqueue.NewPairing[uint8, EM](),
+		workingQueue:     pqueue.NewPairing[uint8, EM](),
+		subscribeQueue:   pqueue.NewCircularBuffer[SU](),
+		unsubscribeQueue: pqueue.NewCircularBuffer[SU](),
+		wp:               newWorkerPool(options.Demuxers),
 	}
 
 	return b
 }
 
 func (b *Bus[EM, SU]) Tick() {
-	b.lockBufferQueue()
-	defer b.unlockBufferQueue()
+	b.updateSubscribers()
 
-	// TODO: Honestly, I just got lazy. It is inevitable that I will begrudgingly return to this later.
-	b.workingQueue.(*pqueue.Binary[uint8, EM]).Meld(b.bufferQueue.(*pqueue.Binary[uint8, EM]))
+	b.bufferQueueMu.Lock()
+	b.workingQueue.(*pqueue.Pairing[uint8, EM]).Meld(b.bufferQueue.(*pqueue.Pairing[uint8, EM]))
+	b.bufferQueueMu.Unlock()
+
 	for em, ok := b.workingQueue.Pop(); ok; em, ok = b.workingQueue.Pop() {
 		b.demux(em)
 	}
+
+	b.wp.wait()
 }
 
 func (b *Bus[EM, SU]) Subscribe(s SU) {
@@ -78,13 +85,10 @@ func (b *Bus[EM, SU]) Subscribe(s SU) {
 		return
 	}
 
-	actual, loaded := b.subscribers.LoadOrStore(topic, []SU{s})
-	if !loaded {
-		return
-	}
+	b.subscribeQueueMu.Lock()
+	defer b.subscribeQueueMu.Unlock()
 
-	actual = append(actual, s)
-	b.subscribers.Store(topic, actual)
+	b.subscribeQueue.Push(s)
 }
 
 func (b *Bus[EM, SU]) Unsubscribe(s SU) {
@@ -93,52 +97,20 @@ func (b *Bus[EM, SU]) Unsubscribe(s SU) {
 		return
 	}
 
-	subs, loaded := b.subscribers.Load(topic)
-	if !loaded {
-		return
-	}
+	b.unsubscribeQueueMu.Lock()
+	defer b.unsubscribeQueueMu.Unlock()
 
-	for i, x := range subs {
-		if x.ID() != s.ID() {
-			continue
-		}
-
-		subs = append(subs[:i], subs[i+1:]...)
-		b.subscribers.Store(topic, subs)
-		return
-	}
+	b.unsubscribeQueue.Push(s)
 }
 
 func (b *Bus[EM, SU]) Post(em EM, priority uint8) {
-	b.bufferQueueCond.L.Lock()
-	defer b.bufferQueueCond.L.Unlock()
-
-	for b.bufferQueueLocked {
-		b.bufferQueueCond.Wait()
-	}
-
+	b.bufferQueueMu.Lock()
 	b.bufferQueue.Push(em, priority)
+	b.bufferQueueMu.Unlock()
 }
 
 func (b *Bus[EM, SU]) Size() int {
 	return b.bufferQueue.Size() + b.workingQueue.Size()
-}
-
-func (b *Bus[EM, SU]) lockBufferQueue() {
-	b.bufferQueueCond.L.Lock()
-	defer b.bufferQueueCond.L.Unlock()
-
-	b.bufferQueueLocked = true
-}
-
-func (b *Bus[EM, SU]) unlockBufferQueue() {
-	b.bufferQueueCond.L.Lock()
-	defer func() {
-		b.bufferQueueCond.L.Unlock()
-		b.bufferQueueCond.Broadcast()
-	}()
-
-	b.bufferQueueLocked = false
 }
 
 func (b *Bus[EM, SU]) demux(em EM) {
@@ -146,24 +118,70 @@ func (b *Bus[EM, SU]) demux(em EM) {
 		return
 	}
 
-	subs, ok := b.subscribers.Load(em.Topic())
-	if !ok {
+	subs, loaded := b.subscribers.Load(em.Topic())
+	if !loaded {
 		return
 	}
 
-	for _, sub := range subs {
-		b.demuxSema <- struct{}{}
-		go func(sub Subscriber[EM]) {
-			defer func() { <-b.demuxSema }()
-			err := sub.Handle(em)
-			if err == nil {
-				return
-			}
-
-			errEm := b.options.ErrorBuilder(err)
-			if errTyped, ok := errEm.(EM); ok {
-				b.Post(errTyped, 0)
-			}
-		}(sub)
+	for _, s := range subs {
+		b.wp.post(func() { b.handlingAgent(em, s) })
 	}
+}
+
+func (b *Bus[EM, SU]) handlingAgent(em EM, s SU) {
+	err := s.Handle(em)
+	if err == nil {
+		return
+	}
+
+	errEm := b.options.ErrorBuilder(err)
+	if errTyped, ok := errEm.(EM); ok {
+		b.Post(errTyped, 0)
+	}
+}
+
+func (b *Bus[EM, SU]) updateSubscribers() {
+	b.unsubscribeQueueMu.Lock()
+	b.subscribeQueueMu.Lock()
+	defer b.unsubscribeQueueMu.Unlock()
+	defer b.subscribeQueueMu.Unlock()
+
+	for s, ok := b.unsubscribeQueue.Pop(); ok; s, ok = b.unsubscribeQueue.Pop() {
+		if i, found := b.findSubscriber(s); found {
+			subs, _ := b.subscribers.Load(s.Topic())
+			subs = append(subs[:i], subs[i+1:]...)
+			b.subscribers.Store(s.Topic(), subs)
+		}
+	}
+
+	for s, ok := b.subscribeQueue.Pop(); ok; s, ok = b.subscribeQueue.Pop() {
+		actual, loaded := b.subscribers.Load(s.Topic())
+		if !loaded {
+			b.subscribers.Store(s.Topic(), []SU{s})
+			continue
+		}
+
+		// Do not allow duplicate subscribers.
+		if _, found := b.findSubscriber(s); found {
+			continue
+		}
+
+		actual = append(actual, s)
+		b.subscribers.Store(s.Topic(), actual)
+	}
+}
+
+func (b *Bus[EM, SU]) findSubscriber(s SU) (index int, found bool) {
+	subs, loaded := b.subscribers.Load(s.Topic())
+	if !loaded {
+		return 0, false
+	}
+
+	for i, x := range subs {
+		if x.ID() == s.ID() {
+			return i, true
+		}
+	}
+
+	return 0, false
 }

--- a/bus/test/benchmark_test.go
+++ b/bus/test/benchmark_test.go
@@ -37,6 +37,7 @@ func BenchmarkTick(b *testing.B) {
 		bs.Post(new(MockEmittable), 0)
 	}
 
+	b.ResetTimer()
 	b.StartTimer()
 	bs.Tick()
 	b.StopTimer()

--- a/bus/wp.go
+++ b/bus/wp.go
@@ -1,0 +1,34 @@
+package bus
+
+import (
+	"sync"
+)
+
+// A workerPool manages a bounded number of workers that execute tasks in a concurrent fashion.
+type workerPool struct {
+	sema chan struct{}
+	wg   sync.WaitGroup
+}
+
+func newWorkerPool(n int) *workerPool {
+	return &workerPool{
+		sema: make(chan struct{}, n),
+	}
+}
+
+// post submits a task for execution.
+func (p *workerPool) post(task func()) {
+	p.wg.Add(1)
+	p.sema <- struct{}{}
+
+	go func() {
+		task()
+		<-p.sema
+		p.wg.Done()
+	}()
+}
+
+// wait blocks until all tasks posted to the workerPool have been completed.
+func (p *workerPool) wait() {
+	p.wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.24.5
 
 require (
 	github.com/AndrewChon/gsync v1.1.0
-	github.com/AndrewChon/pqueue v1.1.0
+	github.com/AndrewChon/pqueue v1.2.2
 	github.com/google/uuid v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,11 @@ github.com/AndrewChon/pqueue v1.0.0 h1:taDu91GMSI7qeYJO9G0WFc5IUFMOIHbww7hm9SWCm
 github.com/AndrewChon/pqueue v1.0.0/go.mod h1:mjC/UOegM7HBWDDvcou0iSNHExpbmJQo4JqoQ7hzQyE=
 github.com/AndrewChon/pqueue v1.1.0 h1:HS/R0TCseq0YWKLlbXvtOjUb0WLGlyzttxIHGEyJp5M=
 github.com/AndrewChon/pqueue v1.1.0/go.mod h1:mjC/UOegM7HBWDDvcou0iSNHExpbmJQo4JqoQ7hzQyE=
+github.com/AndrewChon/pqueue v1.2.0 h1:Nq3s68TyGvX+gLOXxTUI4c/OmDSmyVsRJ4ah8ZokY1s=
+github.com/AndrewChon/pqueue v1.2.0/go.mod h1:mjC/UOegM7HBWDDvcou0iSNHExpbmJQo4JqoQ7hzQyE=
+github.com/AndrewChon/pqueue v1.2.1 h1:Kp7XEcva9T1mY2sLZUlI8smzpSzuG2GmIF6SQ0KWkNY=
+github.com/AndrewChon/pqueue v1.2.1/go.mod h1:mjC/UOegM7HBWDDvcou0iSNHExpbmJQo4JqoQ7hzQyE=
+github.com/AndrewChon/pqueue v1.2.2 h1:WvagOEUZjMjdWZLw2vDbIJAvTPCdzWRbuQKNuCtcQkM=
+github.com/AndrewChon/pqueue v1.2.2/go.mod h1:mjC/UOegM7HBWDDvcou0iSNHExpbmJQo4JqoQ7hzQyE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
- Subscriptions are now buffered and processed at the start of the tick.
- Fixed the demultiplexing worker pool.
- Switched back to a Pairing queue for drastically faster melds at the expense of slightly slower pops.
- Made a small fix to the benchmark.